### PR TITLE
made slowparse aware of HTML in CSS context, as well as comments

### DIFF
--- a/slowparse.js
+++ b/slowparse.js
@@ -604,9 +604,9 @@ var Slowparse = (function() {
     },
     // #### CSS Comment Filtering
     //
-    // Here we filter a token so that its value has no CSS comments in it,
-    // and it's start/end points to the token's text with leading and trailing
-    // comments removed.
+    // Here we filter a token so that its start and end positions
+    // point to the content without leading and trailing comments,
+    // with comments in the token.value completely removed.
     filterComments: function(token) {
       var text = token.value,
           tsize = text.length,
@@ -679,8 +679,7 @@ var Slowparse = (function() {
       var selector = token.value,
           selectorStart = token.interval.start,
           selectorEnd = token.interval.end;
-      
-      //selector = this.stripComments(selector, selectorStart).trim();
+
       if (selector === '') {
         this._parseSelector();
         return;
@@ -797,7 +796,6 @@ var Slowparse = (function() {
           propertyStart = token.interval.start,
           propertyEnd = token.interval.end;
 
-      //property = this.stripComments(property, propertyStart).trim();
       if (property === '') {
         this._parseDeclaration(selector, selectorStart);
         return;
@@ -874,12 +872,10 @@ var Slowparse = (function() {
       
       
       this.filterComments(token);
-      //token.value = token.value.trim();
       var value = token.value,
           valueStart = token.interval.start,
           valueEnd = token.interval.end;
 
-      //value = this.stripComments(value, valueStart).trim();
       if (value === '') {
         throw new ParseError("MISSING_CSS_VALUE", this, this.stream.pos-1,
                              this.stream.pos);

--- a/spec/errors.base.html
+++ b/spec/errors.base.html
@@ -127,3 +127,6 @@
   <p>The CSS comment <em data-highlight="{{start}}">here</em>
     doesn't end with a <code>*/</code>.</p>
 </div>
+<div class="error-msg HTML_CODE_IN_CSS_BLOCK">
+  <p>HTML code was detected in CSS context starting <em data-highlight="{{html.start}},{{html.end}}">here</em>
+</div>

--- a/spec/index.html
+++ b/spec/index.html
@@ -504,6 +504,40 @@ h1.error-category {
   }
   </script>
 </div>
+
+<div class="test">
+  <script type="text/x-bad-html">
+    <style>
+      <!-- html comment in CSS block -->
+    </style>
+  </script>
+  <script type="application/json">
+  {
+    "type": "HTML_CODE_IN_CSS_BLOCK",
+    "html": {
+      "start": 13,
+      "end": 14
+    }
+  }
+    </script>
+</div>
+<div class="test">
+  <script type="text/x-bad-html">
+    <style>
+      <p>html code in CSS block</p>
+    </style>
+  </script>
+  <script type="application/json">
+  {
+    "type": "HTML_CODE_IN_CSS_BLOCK",
+    "html": {
+      "start": 13,
+      "end": 14
+    }
+  }
+  </script>
+</div>
+
 <div class="test">
   <script type="text/x-bad-html">
     <style> /* unterminated comment

--- a/test/test-slowparse.js
+++ b/test/test-slowparse.js
@@ -325,7 +325,6 @@ testStyleSheet("parsing of CSS rule w/ vendor prefixes",
     });
 });
 
-
 test("replaceEntityRefs", function() {
   [
     ["&lt;", "<"],

--- a/test/test-slowparse.js
+++ b/test/test-slowparse.js
@@ -273,22 +273,22 @@ testStyleSheet("parsing of empty CSS rule w/ comment",
 });
 
 testStyleSheet("parsing of CSS rule w/ comments",
-               "/** comment 1 **/ bo/* comment 2 */dy /*comment 3*/{ /* c4 */ co/*c5*/lor/*c6*/: /*c7*/pi/*c8*/nk/*c9*; /***** c9 *****/}",
+               "/** comment 1 **/ bo/* comment 2 */dy /*comment 3*/{ /* c4 */ co/*c5*/lor/*c6*/: /*c7*/pi/*c8*/nk/*c9****** c9 *****/}",
                function(html, css, styleContents) {
     equal(styleContents.parseInfo.rules.length, 1);
     equal(styleContents.parseInfo.rules[0].declarations.properties.length, 1);
     assertParseIntervals(html, styleContents, "style", {
-      'parseInfo': '/** comment 1 **/ bo/* comment 2 */dy /*comment 3*/{ /* c4 */ co/*c5*/lor/*c6*/: /*c7*/pi/*c8*/nk/*c9*; /***** c9 *****/}',
-      'parseInfo.rules[0].selector': '/** comment 1 **/ bo/* comment 2 */dy /*comment 3*/',
-      'parseInfo.rules[0].declarations': '{ /* c4 */ co/*c5*/lor/*c6*/: /*c7*/pi/*c8*/nk/*c9*; /***** c9 *****/}',
-      'parseInfo.rules[0].declarations.properties[0].name': '/* c4 */ co/*c5*/lor/*c6*/',
-      'parseInfo.rules[0].declarations.properties[0].value': '/*c7*/pi/*c8*/nk/*c9*; /***** c9 *****/',
+      'parseInfo': '/** comment 1 **/ bo/* comment 2 */dy /*comment 3*/{ /* c4 */ co/*c5*/lor/*c6*/: /*c7*/pi/*c8*/nk/*c9****** c9 *****/}',
+      'parseInfo.rules[0].selector': 'bo/* comment 2 */dy',
+      'parseInfo.rules[0].declarations': '{ /* c4 */ co/*c5*/lor/*c6*/: /*c7*/pi/*c8*/nk/*c9****** c9 *****/}',
+      'parseInfo.rules[0].declarations.properties[0].name': 'co/*c5*/lor',
+      'parseInfo.rules[0].declarations.properties[0].value': 'pi/*c8*/nk',
     });
     
     equal(styleContents.parseInfo.rules[0].selector.value, "body");
     equal(styleContents.parseInfo.rules[0].declarations.properties[0].name.value, "color");
     equal(styleContents.parseInfo.rules[0].declarations.properties[0].value.value, "pink");
-    
+
     equal(styleContents.parseInfo.comments.length, 9);
     assertParseIntervals(html, styleContents, "style", {
       'parseInfo.comments[0]': '/** comment 1 **/',
@@ -299,7 +299,7 @@ testStyleSheet("parsing of CSS rule w/ comments",
       'parseInfo.comments[5]': '/*c6*/',
       'parseInfo.comments[6]': '/*c7*/',
       'parseInfo.comments[7]': '/*c8*/',
-      'parseInfo.comments[8]': '/*c9*; /***** c9 *****/'
+      'parseInfo.comments[8]': '/*c9****** c9 *****/'
     });
 });
 


### PR DESCRIPTION
slowparse will now throw an HTML_CODE_IN_CSS_BLOCK error when html elements or html comments are used inside a CSS block, and sets up the correct intervals for CSS things with (proper) comments so that leading/trailing comments are not part of the interval range
