### PR TITLE
added CDATA intepreting, rather than markup parsing, for textarea content 

### DIFF
--- a/test/test-slowparse.js
+++ b/test/test-slowparse.js
@@ -136,11 +136,16 @@ test("parsing of HTML comments with '--' in them", function() {
 });
 
 test("parsing of CDATA in <textarea> elements", function() {
-  var html = "<textarea readonly>\nThis is CDATA with <p>, <i> and"+
-             " <script> in it.\nThis should not trigger errors.</textarea>";
+  var text = "\nThis is CDATA with <p>, <i> and" +
+             " <script> in it.\nThis should not trigger errors.";
+  var html = "<textarea>" + text + "</textarea>";
   var doc = parseWithoutErrors(html);
-  equal(documentFragmentHTML(doc), html,
-        "serialization of generated DOM matches original HTML");
+
+  equal(doc.childNodes.length, 1, "doc has one child node");
+  equal(doc.childNodes[0].nodeName, "TEXTAREA", "child node is <textarea>");
+  equal(doc.childNodes[0].childNodes.length, 1, "textarea has one child");
+  equal(doc.childNodes[0].childNodes[0].nodeValue, text,
+        "textarea contents are ok");
 });
 
 testManySnippets("parsing of HTML is case-insensitive", [

--- a/test/test-slowparse.js
+++ b/test/test-slowparse.js
@@ -135,6 +135,14 @@ test("parsing of HTML comments with '--' in them", function() {
         "serialization of generated DOM matches original HTML");
 });
 
+test("parsing of CDATA in <textarea> elements", function() {
+  var html = "<textarea readonly>\nThis is CDATA with <p>, <i> and"+
+             " <script> in it.\nThis should not trigger errors.</textarea>";
+  var doc = parseWithoutErrors(html);
+  equal(documentFragmentHTML(doc), html,
+        "serialization of generated DOM matches original HTML");
+});
+
 testManySnippets("parsing of HTML is case-insensitive", [
   '<P CLASS="FOO">hi</P>',
   '<P class="FOO">hi</P>',


### PR DESCRIPTION
uses preexisting errors, has a test to make sure that textarea content with normally "illegal" chars is not parsed as markup.
