### PR TITLE
comments and @rule { {} {} {} } nesting fixes

### DIFF
--- a/test/test-slowparse.js
+++ b/test/test-slowparse.js
@@ -657,6 +657,24 @@ module.exports = function(Slowparse, window, document, validators) {
     ok(!result.error, "@-*-keyframes accepted</p>");
   });
 
+  test("@keyframes css block with leading block comment", function() {
+    var html = "<style>/*\n  keyframe test\n*/\n@keyframes { 0% { opacity: 0; } 100% { opacity: 1.0; } } .test { opacity: 0; }</style>";
+    var result = parse(html);
+    ok(!result.error, "@keyframes accepted</p>");
+  });
+
+  test("@keyframes css block with trailing block comment", function() {
+    var html = "<style>\n@keyframes { 0% { opacity: 0; } 100% { opacity: 1.0; } } .test { opacity: 0; }\n/*\n  keyframe test\n*/\n</style>";
+    var result = parse(html);
+    ok(!result.error, "@keyframes accepted</p>");
+  });
+
+  test("@keyframes css block with leading and trailing block comment", function() {
+    var html = "<style>/*\n  keyframe test\n*/\n@keyframes { 0% { opacity: 0; } 100% { opacity: 1.0; } } .test { opacity: 0; }\n/*\n  keyframe test\n*/\n</style>";
+    var result = parse(html);
+    ok(!result.error, "@keyframes accepted</p>");
+  });
+
   test("@media rule", function() {
     var html = "<style>@media (max-width: 100px) { .class { background: white; } }</style>";
     var result = parse(html);


### PR DESCRIPTION
fixes #62 by removing comments before parsing the CSS selector, trimming the found selector, and making sure that for keyframes/media queries we note that we're in a nested block context, so that `} }` at the end doesn't throw an `UNFINISHED_CSS_SELECTOR` error.

Three unit tests have been added to cover the parsing problems originally signalled.
