### PR TITLE
content values now allow semi-colons in quoted strings

### DIFF
--- a/test/test-slowparse.js
+++ b/test/test-slowparse.js
@@ -615,16 +615,28 @@ module.exports = function(Slowparse, window, document, validators) {
     equal(result.error, expected, "bad omission error for <p>");
   });
 
+  test("testing CSS 'content' property values with semi-colons", function() {
+    var html = "<style>div:before { content: '&lt;' attr(test) 'test'; content: \"&lt;\"; }</style>";
+    var result = parse(html);
+    ok(!result.error, "semi-colons accepted");
+  });
+
+  test("testing CSS 'content' property values with semi-colons inside nested quotes", function() {
+    var html = "<style>div:before { content: 'let\\'s try \";\", eh?'; }</style>";
+    var result = parse(html);
+    ok(!result.error, "semi-colons accepted");
+  });
+
   test("@keyframes css block", function() {
     var html = "<style>@keyframes { 0% { opacity: 0; } 100% { opacity: 1.0; } } .test { opacity: 0; }</style>";
     var result = parse(html);
-    ok(!result.error, "@keyframes accepted</p>");
+    ok(!result.error, "@keyframes accepted");
   });
 
   test("@keyframes css block with named frame", function() {
     var html = "<style>@keyframes animation1 { 0% { left: 260px; top: -10%; } 100% { left: 260px; top: 100%; } }</style>";
     var result = parse(html);
-    ok(!result.error, "@keyframes accepted</p>");
+    ok(!result.error, "@keyframes accepted");
   });
 
   test("@keyframes css block with typo (@keyfarmes). pass = not accepted", function() {
@@ -645,49 +657,49 @@ module.exports = function(Slowparse, window, document, validators) {
   test("@-moz-keyframes css block", function() {
     var html = "<style>@-moz-keyframes { 0% { opacity: 0; } 100% { opacity: 1.0; } } .test { opacity: 0; }</style>";
     var result = parse(html);
-    ok(!result.error, "@-*-keyframes accepted</p>");
+    ok(!result.error, "@-*-keyframes accepted");
   });
 
   test("@-webkit-keyframes css block", function() {
     var html = "<style>@-webkit-keyframes { 0% { opacity: 0; } 100% { opacity: 1.0; } } .test { opacity: 0; }</style>";
     var result = parse(html);
-    ok(!result.error, "@-*-keyframes accepted</p>");
+    ok(!result.error, "@-*-keyframes accepted");
   });
 
   test("@keyframes css block with leading block comment", function() {
     var html = "<style>/*\n  keyframe test\n*/\n@keyframes { 0% { opacity: 0; } 100% { opacity: 1.0; } } .test { opacity: 0; }</style>";
     var result = parse(html);
-    ok(!result.error, "@keyframes accepted</p>");
+    ok(!result.error, "@keyframes accepted");
   });
 
   test("@keyframes css block with trailing block comment", function() {
     var html = "<style>\n@keyframes { 0% { opacity: 0; } 100% { opacity: 1.0; } } .test { opacity: 0; }\n/*\n  keyframe test\n*/\n</style>";
     var result = parse(html);
-    ok(!result.error, "@keyframes accepted</p>");
+    ok(!result.error, "@keyframes accepted");
   });
 
   test("@keyframes css block with leading and trailing block comment", function() {
     var html = "<style>/*\n  keyframe test\n*/\n@keyframes { 0% { opacity: 0; } 100% { opacity: 1.0; } } .test { opacity: 0; }\n/*\n  keyframe test\n*/\n</style>";
     var result = parse(html);
-    ok(!result.error, "@keyframes accepted</p>");
+    ok(!result.error, "@keyframes accepted");
   });
 
   test("@media rule", function() {
     var html = "<style>@media (max-width: 100px) { .class { background: white; } }</style>";
     var result = parse(html);
-    ok(!result.error, "@media accepted</p>");
+    ok(!result.error, "@media accepted");
   });
 
   test("@media rule (complex)", function() {
     var html = "<style>@media (min-width: 700px), handheld and (orientation: landscape) { .class { background: white; } }</style>";
     var result = parse(html);
-    ok(!result.error, "@media accepted</p>");
+    ok(!result.error, "@media accepted");
   });
 
   test("@font-face rule", function() {
     var html = "<style>@font-face { font-family: 'snickerdoodle'; } .test { opacity: 0; }</style>";
     var result = parse(html);
-    ok(!result.error, "@font-face accepted</p>");
+    ok(!result.error, "@font-face accepted");
   });
 
   test("@font-face rule with typo (@font-faec). pass = not accepted", function() {


### PR DESCRIPTION
Fixes #61. Added special parsing for `content: ....` values, since their quoted contexts can make things really fun. Two unit tests were added to cover checking that text inside quoted context is not treated as value terminator.
