### PR TITLE
Use shims of document nodes instead of an active DOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "test"
   },
   "scripts": {
-    "test": "browserify ./src/index.js -o slowparse.js --standalone Slowparse & node test.js"
+    "build": "browserify ./src/index.js -o slowparse.js --standalone Slowparse",
+    "test": "node test.js",
+    "dev": "npm run build && npm run test"
   },
   "repository": {
     "type": "git",

--- a/src/DocumentFragment.js
+++ b/src/DocumentFragment.js
@@ -1,0 +1,35 @@
+  // ### DocumentFragment Shim
+  //
+  // A representation of a document fragment that can be normally generated
+  // by calling `document.createDocumentFragment`. Since the document fragment
+  // is itself a node, it inherits all properties of a node.
+module.exports = (function(){
+  "use strict";
+
+  var Node = require("./Node");
+
+  function DocumentFragment() {
+    this.node = new Node(Node.DOCUMENT_FRAGMENT_NODE, "#document-fragment");
+    this.node._ownerDocument = this;
+  }
+
+  DocumentFragment.prototype = {
+    createTextNode: function(data) {
+      return new Node(Node.TEXT_NODE, "#text", data);
+    },
+    createElementNS: function(namespaceURI, qualifiedName) {
+      return new Node(Node.ELEMENT_NODE, qualifiedName, false, namespaceURI);
+    },
+    createElement: function(tagName) {
+      return this.createElementNS(false, tagName);
+    },
+    createComment: function(data) {
+      return new Node(Node.COMMENT_NODE, "#comment", data);
+    },
+    createAttribute: function(name) {
+      return new Node(Node.ATTRIBUTE_NODE, name);
+    }
+  };
+
+  return DocumentFragment;
+}());

--- a/src/Node.js
+++ b/src/Node.js
@@ -1,0 +1,119 @@
+  // ### DOM Node Shim
+  //
+  // This represents a superficial form of a DOM node which contains most of
+  // the properties that a regular DOM node would contain, but only the ones
+  // needed by slowparse.
+module.exports = (function(){
+  "use strict";
+
+  var voidHtmlElements = require("./voidHtmlElements");
+
+  function Node(nodeType, nodeName, nodeValue, namespaceURI) {
+    this.nodeType = nodeType;
+    this.nodeValue = nodeValue || "";
+    this.namespaceURI = namespaceURI || "";
+    this.parentNode = false;
+    this.nextSibling = false;
+    this.isVoid = voidHtmlElements.indexOf(nodeName) > -1;
+    this.childNodes = [];
+    this.attributes = [];
+    this._attributeMap = {};
+    switch(this.nodeType) {
+      case Node.ELEMENT_NODE:
+        this.nodeName = nodeName.toUpperCase();
+        break;
+      case Node.ATTRIBUTE_NODE:
+        this.nodeName = nodeName.toLowerCase();
+        break;
+      default:
+        this.nodeName = nodeName;
+    }
+  }
+
+  Node.prototype = {
+    // Add a node to the current node as a child
+    appendChild: function(node) {
+      var lastChild = this.childNodes.slice(-1)[0];
+      if(lastChild) {
+        lastChild.nextSibling = node;
+      }
+
+      node.parentNode = this;
+      this.childNodes.push(node);
+    },
+    // Create a deep copy of the current node
+    clone: function() {
+      var node = new Node(this.nodeType, this.nodeName, this.nodeValue, this.namespaceURI);
+      node.nextSibling = this.nextSibling ? this.nextSibling.clone() : false;
+      node.isVoid = this.isVoid;
+      node.childNodes = this.childNodes.map(function(childNode) {
+        return childNode.clone();
+      });
+      node.attributes = this.attributes.map(function(attribute) {
+        return attribute.clone();
+      });
+      node._attributeMap = this._attributeMap;
+
+      return node;
+    },
+    // Get the attribute value of an element node
+    getAttribute: function(name) {
+      return this.nodeType === Node.ELEMENT_NODE && this._attributeMap[name.toLowerCase()];
+    }
+  };
+
+  Object.defineProperties(Node.prototype, {
+    "innerHTML": {
+      get: function() {
+        if(this.nodeType !== Node.ELEMENT_NODE) {
+          return null;
+        }
+
+        var innerHTML = "";
+
+        this.childNodes.forEach(function(childNode) {
+          innerHTML += childNode.outerHTML || "";
+        });
+
+        return innerHTML;
+      }
+    },
+    "outerHTML": {
+      get: function() {
+        if(this.nodeType === Node.ATTRIBUTE_NODE) {
+          return null;
+        }
+        if(this.nodeType === Node.COMMENT_NODE) {
+          return "<!--" + this.nodeValue + "-->";
+        }
+        if(this.nodeType !== Node.ELEMENT_NODE) {
+          return this.nodeValue;
+        }
+
+        var attributes = this._attributeMap;
+        var attributeStr = "";
+        attributeStr = Object.keys(attributes).map(function(attrName) {
+          return attrName + '="' + attributes[attrName] + '"';
+        }).join(" ");
+        if(attributeStr.length > 0) {
+          attributeStr = " " + attributeStr;
+        }
+
+        var nodeName = this.nodeName.toLowerCase();
+        var openingTag = "<" + nodeName + attributeStr + ">";
+        var closingTag = this.isVoid ? "" : "</" + nodeName + ">";
+
+        return openingTag + (this.innerHTML || "") + closingTag;
+      }
+    }
+  });
+
+  // Different node type constants
+  Node.ELEMENT_NODE = 1;
+  Node.ATTRIBUTE_NODE = 2;
+  Node.TEXT_NODE = 3;
+  Node.COMMENT_NODE = 8;
+  Node.DOCUMENT_FRAGMENT_NODE = 11;
+
+  return Node;
+}());

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@
           errorDetectors = options.errorDetectors || [],
           disallowActiveAttributes = (typeof options.disallowActiveAttributes === "undefined") ? false : options.disallowActiveAttributes;
 
-      domBuilder = new DOMBuilder(document, disallowActiveAttributes);
+      domBuilder = new DOMBuilder(disallowActiveAttributes);
       parser = new HTMLParser(stream, domBuilder);
 
       try {
@@ -96,11 +96,11 @@
 
       errorDetectors.forEach(function(detector) {
         if (!error)
-          error = detector(html, domBuilder.fragment) || null;
+          error = detector(html, domBuilder.fragment.node) || null;
       });
 
       return {
-        document: domBuilder.fragment,
+        document: domBuilder.fragment.node,
         contexts: domBuilder.contexts,
         warnings: warnings,
         error: error

--- a/src/voidHtmlElements.js
+++ b/src/voidHtmlElements.js
@@ -1,0 +1,4 @@
+// A list of void HTML elements
+module.exports = ["area", "base", "br", "col", "command", "embed", "hr",
+                  "img", "input", "keygen", "link", "meta", "param",
+                  "source", "track", "wbr"];

--- a/test/node/qunit-shim.js
+++ b/test/node/qunit-shim.js
@@ -100,7 +100,7 @@ module.exports = function(Slowparse, jsdom) {
     var document = doc._ownerDocument;
     var div = document.createElement("div");
     for (var i = 0; i < doc.childNodes.length; i++) {
-      div.appendChild(doc.childNodes[i].cloneNode(true));
+      div.appendChild(doc.childNodes[i].clone());
     }
     return div.innerHTML;
   }

--- a/test/test-slowparse.js
+++ b/test/test-slowparse.js
@@ -1,5 +1,7 @@
 module.exports = function(Slowparse, window, document, validators) {
 
+  var Node = require('../src/Node');
+
   var ok = validators.ok;
   var equal = validators.equal;
   var test = validators.test;
@@ -129,7 +131,7 @@ module.exports = function(Slowparse, window, document, validators) {
     equal(script.childNodes.length, 1, "<script> has one child");
     var textNode = script.childNodes[0];
 
-    equal(textNode.nodeType, textNode.TEXT_NODE,
+    equal(textNode.nodeType, Node.TEXT_NODE,
           "<script>'s child is a text node.");
     assertParseIntervals(html, textNode, "textNode", {
       'parseInfo': 'x < 3;'
@@ -156,7 +158,7 @@ module.exports = function(Slowparse, window, document, validators) {
 
     var textNode = p.childNodes[0];
 
-    equal(textNode.nodeType, textNode.TEXT_NODE, "<p>'s child is a text node.");
+    equal(textNode.nodeType, Node.TEXT_NODE, "<p>'s child is a text node.");
     assertParseIntervals(html, textNode, "textNode", {
       'parseInfo': 'hello there'
     });


### PR DESCRIPTION
We do not need a 'real' DOM to parse HTML, as we are only interested in the errors present in the given HTML. Therefore, this patch creates a DOM shim that is used everywhere instead.
