### PR TITLE
Autoclose tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "build": "browserify ./src/index.js -o slowparse.js --standalone Slowparse",
-    "test": "node test.js",
-    "dev": "npm run build && npm run test"
+    "debug": "npm run build && node inspect test.js",
+    "test": "npm run build && node test.js"
   },
   "repository": {
     "type": "git",

--- a/slowparse.js
+++ b/slowparse.js
@@ -973,11 +973,18 @@ module.exports = (function(){
         };
         var openTagName = this.domBuilder.currentNode.nodeName.toLowerCase();
         if (closeTagName != openTagName) {
+          // Are we dealing with a rogue </ here?
+          if (closeTagName === "") {
+            throw new ParseError("MISSING_CLOSING_TAG_NAME", token, openTagName, this.domBuilder.currentNode.closeWarnings);
+          }
 
+          // Are we dealing with a tag that is closed in the source,
+          // even though based on DOM parsing it already got closed?
           if (this.domBuilder.currentNode.closeWarnings) {
             throw new ParseError("MISMATCHED_CLOSE_TAG_DUE_TO_EARLIER_AUTO_CLOSING", this, closeTagName, token);
           }
 
+          // This is just a regular old mismatched closing tag.
           throw new ParseError("MISMATCHED_CLOSE_TAG", this, openTagName, closeTagName, token);
         }
         this._parseEndCloseTag();
@@ -1475,6 +1482,23 @@ module.exports = (function() {
       return {
         openTag: openTag,
         cursor: openTag.start
+      };
+    },
+    MISSING_CLOSING_TAG_NAME: function(token, openTagName, autocloseWarnings) {
+      var openTag = this._combine({
+            name: openTagName
+          }, token.interval);
+
+      if (autocloseWarnings) {
+        var tag = autocloseWarnings[0];
+        openTag = this._combine({
+            name: tag.tagName
+          }, tag.parseInfo.openTag);
+      }
+
+      return {
+        openTag: openTag,
+        cursor: token.interval.start
       };
     },
     UNEXPECTED_CLOSE_TAG: function(parser, closeTagName, token) {

--- a/src/HTMLParser.js
+++ b/src/HTMLParser.js
@@ -315,11 +315,18 @@ module.exports = (function(){
         };
         var openTagName = this.domBuilder.currentNode.nodeName.toLowerCase();
         if (closeTagName != openTagName) {
+          // Are we dealing with a rogue </ here?
+          if (closeTagName === "") {
+            throw new ParseError("MISSING_CLOSING_TAG_NAME", token, openTagName, this.domBuilder.currentNode.closeWarnings);
+          }
 
+          // Are we dealing with a tag that is closed in the source,
+          // even though based on DOM parsing it already got closed?
           if (this.domBuilder.currentNode.closeWarnings) {
             throw new ParseError("MISMATCHED_CLOSE_TAG_DUE_TO_EARLIER_AUTO_CLOSING", this, closeTagName, token);
           }
 
+          // This is just a regular old mismatched closing tag.
           throw new ParseError("MISMATCHED_CLOSE_TAG", this, openTagName, closeTagName, token);
         }
         this._parseEndCloseTag();

--- a/src/ParseErrorBuilders.js
+++ b/src/ParseErrorBuilders.js
@@ -51,6 +51,21 @@ module.exports = (function() {
         cursor: closeTag.start
       };
     },
+    MISMATCHED_CLOSE_TAG_DUE_TO_EARLIER_AUTO_CLOSING: function(parser, closeTagName, token) {
+      var warnings = parser.domBuilder.currentNode.closeWarnings,
+          tag = warnings[0],
+          openTag = this._combine({
+            name: tag.tagName
+          }, tag.parseInfo.openTag),
+          closeTag = this._combine({
+            name: closeTagName
+          }, token.interval);
+      return {
+        openTag: openTag,
+        closeTag: closeTag,
+        cursor: closeTag.start
+      };
+    },
     MISMATCHED_CLOSE_TAG: function(parser, openTagName, closeTagName, token) {
       var openTag = this._combine({
             name: openTagName

--- a/src/ParseErrorBuilders.js
+++ b/src/ParseErrorBuilders.js
@@ -42,6 +42,23 @@ module.exports = (function() {
         cursor: openTag.start
       };
     },
+    MISSING_CLOSING_TAG_NAME: function(token, openTagName, autocloseWarnings) {
+      var openTag = this._combine({
+            name: openTagName
+          }, token.interval);
+
+      if (autocloseWarnings) {
+        var tag = autocloseWarnings[0];
+        openTag = this._combine({
+            name: tag.tagName
+          }, tag.parseInfo.openTag);
+      }
+
+      return {
+        openTag: openTag,
+        cursor: token.interval.start
+      };
+    },
     UNEXPECTED_CLOSE_TAG: function(parser, closeTagName, token) {
       var closeTag = this._combine({
             name: closeTagName

--- a/test.js
+++ b/test.js
@@ -10,7 +10,12 @@ var Slowparse = require("./slowparse.js"),
     validators = require("./test/node/qunit-shim.js")(Slowparse, JSDOM);
 
 console.log("Testing Slowparse library:");
-var failureCount = require("./test/test-slowparse.js")(Slowparse, window, document, validators);
-if (failureCount > 0) { console.log(failureCount + " tests failed."); }
+
+var testRunner = require("./test/test-slowparse.js");
+var failureCount = testRunner(Slowparse, window, document, validators);
+
+if (failureCount > 0) {
+	console.log(`${failureCount} test${failureCount>1 ? 's' : ''} failed.`);
+}
 
 process.exit(failureCount);

--- a/test/test-slowparse.js
+++ b/test/test-slowparse.js
@@ -831,6 +831,15 @@ module.exports = function(Slowparse, window, document, validators) {
     });
   });
 
+  test("testing </ and auto-closed tags", function () {
+    var html = '<body><div><p><h1>lol</h1></</div></body>';
+    var result = parse(html);
+    equal(result.error, {
+      type: 'MISSING_CLOSING_TAG_NAME',
+      openTag: { name: 'p', start: 11, end: 14 },
+      cursor: 26
+    });
+  });
 
   // specifically CSS testing
 

--- a/test/test-slowparse.js
+++ b/test/test-slowparse.js
@@ -809,6 +809,29 @@ module.exports = function(Slowparse, window, document, validators) {
   });
 
 
+  test("correctly flag the opening tag for an auto-closed closing tag", function () {
+    var html = '<body><p><h1><a href="">test</a></h1></p></body>';
+    var result = parse(html);
+    equal(result.error, {
+      type: 'MISMATCHED_CLOSE_TAG_DUE_TO_EARLIER_AUTO_CLOSING',
+      openTag: { name: 'p', start: 6, end: 9 },
+      closeTag: { name: 'p', start: 37, end: 40 },
+      cursor: 37
+    });
+  });
+
+  test("correctly flag the opening tag in the source for a block closer with auto-closed flow element", function () {
+    var html = '<body><p><h1>lol</h1></h2></p></body>';
+    var result = parse(html);
+    equal(result.error, {
+      type: 'MISMATCHED_CLOSE_TAG_DUE_TO_EARLIER_AUTO_CLOSING',
+      openTag: { name: 'p', start: 6, end: 9 },
+      closeTag: { name: 'h2', start: 21, end: 25 },
+      cursor: 21
+    });
+  });
+
+
   // specifically CSS testing
 
   test("parsing empty CSS document", function() {


### PR DESCRIPTION
Only took years, but this should close https://github.com/mozilla/slowparse/issues/66 by introducing a new error, `MISMATCHED_CLOSE_TAG_DUE_TO_EARLIER_AUTO_CLOSING`, which reports a mismatch between "the code" and "the DOM" when it comes to code like:

```html
<body><p><h1>lol</h1></h2></p></body>
```

This will generate an error like:
```js
{
  "type": "MISMATCHED_CLOSE_TAG_DUE_TO_EARLIER_AUTO_CLOSING",
  "openTag": {
    "start": 9,
    "end": 12
  },
  "closeTag": {
    "name": "h2",
    "start": 32,
    "end": 36
  },
  "cursor": 32
}
```

in which the start tag is `<p>` and the end tag is `</h2>`, but the end tag cannot be resolved due *and* the element the user *thinks* it should be in is the `<p>` element, despite that getting auto-closed in the DOM by that `<h1>`.

As such, rather than a straight forward mismatch to whatever is the parent element according to the DOM, we see a mismatch that is linked to a sibling, not a parent.

This PR also introduces a `MISSING_CLOSING_TAG_NAME` to catch the following error in the HTML:

```html
<body><div><p><h1>lol</h1></</div></body>
```

yielding the following error:

```js
{
  type: 'MISSING_CLOSING_TAG_NAME',
  openTag: { name: 'p', start: 11, end: 14 },
  cursor: 26
}
```

This signals that a `</` was seen, and that it should match the `<p>` but that the DOM is already considered closed for that node.